### PR TITLE
Fix typo in county name from 'Miami-Dad' to 'Miami-Dade'

### DIFF
--- a/packages/usa.florida/README.md
+++ b/packages/usa.florida/README.md
@@ -46,7 +46,7 @@ Contains all the counties of the Florida state:
 * Manatee
 * Marion
 * Marti
-* Miami-Dad
+* Miami-Dade
 * Monroe"
 * Nassau
 * Okaloosa


### PR DESCRIPTION
I am working in something and found your repo, the map I am pretending to use is Florida state and found the typo in Miami-Dade county